### PR TITLE
Add experimental dialog callback

### DIFF
--- a/Content/Python/init_unreal.py
+++ b/Content/Python/init_unreal.py
@@ -38,8 +38,3 @@ class AvalonIntegration(unreal.AvalonPythonBridge):
         unreal.log_warning("Avalon: showing manager window")
         if avalon_detected:
             avalon_unreal.show_manager()
-
-    @unreal.ufunction(override=True)
-    def RunInPython_Workfiles(self):
-        # not implemented yet
-        unreal.log_warning("Avalon: showing workfiles window")

--- a/Content/Python/init_unreal.py
+++ b/Content/Python/init_unreal.py
@@ -38,3 +38,9 @@ class AvalonIntegration(unreal.AvalonPythonBridge):
         unreal.log_warning("Avalon: showing manager window")
         if avalon_detected:
             avalon_unreal.show_manager()
+
+    @unreal.ufunction(override=True)
+    def RunInPython_ExperimentalTools(self):
+        unreal.log_warning("Avalon: showing experimental tools dialog")
+        if avalon_detected:
+            avalon_unreal.show_experimental_tools()

--- a/Content/Python/init_unreal.py
+++ b/Content/Python/init_unreal.py
@@ -43,9 +43,3 @@ class AvalonIntegration(unreal.AvalonPythonBridge):
     def RunInPython_Workfiles(self):
         # not implemented yet
         unreal.log_warning("Avalon: showing workfiles window")
-
-    @unreal.ufunction(override=True)
-    def RunInPython_ProjectManager(self):
-        unreal.log_warning("Avalon: showing project manager window")
-        if avalon_detected:
-            avalon_unreal.show_project_manager()

--- a/Source/Avalon/Private/Avalon.cpp
+++ b/Source/Avalon/Private/Avalon.cpp
@@ -70,24 +70,8 @@ void FAvalonModule::AddMenuEntry(FMenuBuilder& MenuBuilder)
 			FSlateIcon(),
 			FUIAction(FExecuteAction::CreateRaw(this, &FAvalonModule::MenuWorkfiles))
 		);
-
-		MenuBuilder.AddSubMenu(FText::FromString("System"),
-			FText::FromString("System tools"),
-			FNewMenuDelegate::CreateRaw(this, &FAvalonModule::FillSystemSubmenu));
-
 	}
 	MenuBuilder.EndSection();
-}
-
-void FAvalonModule::FillSystemSubmenu(FMenuBuilder& MenuBuilder)
-{
-	// Create the Submenu Entries
-	MenuBuilder.AddMenuEntry(
-		FText::FromString("Project Manager ..."),
-		FText::FromString("Project Manager"),
-		FSlateIcon(),
-		FUIAction(FExecuteAction::CreateRaw(this, &FAvalonModule::MenuProjectManager))
-	);
 }
 
 
@@ -114,11 +98,6 @@ void FAvalonModule::MenuManage() {
 void FAvalonModule::MenuWorkfiles() {
 	UAvalonPythonBridge* bridge = UAvalonPythonBridge::Get();
 	bridge->RunInPython_Workfiles();
-}
-
-void FAvalonModule::MenuProjectManager() {
-	UAvalonPythonBridge* bridge = UAvalonPythonBridge::Get();
-	bridge->RunInPython_ProjectManager();
 }
 
 IMPLEMENT_MODULE(FAvalonModule, Avalon)

--- a/Source/Avalon/Private/Avalon.cpp
+++ b/Source/Avalon/Private/Avalon.cpp
@@ -64,12 +64,6 @@ void FAvalonModule::AddMenuEntry(FMenuBuilder& MenuBuilder)
 			FUIAction(FExecuteAction::CreateRaw(this, &FAvalonModule::MenuManage))
 		);
 
-		MenuBuilder.AddMenuEntry(
-			FText::FromString("Workfiles ..."),
-			FText::FromString("Workfiles"),
-			FSlateIcon(),
-			FUIAction(FExecuteAction::CreateRaw(this, &FAvalonModule::MenuWorkfiles))
-		);
 	}
 	MenuBuilder.EndSection();
 }
@@ -93,11 +87,6 @@ void FAvalonModule::MenuPublish() {
 void FAvalonModule::MenuManage() {
 	UAvalonPythonBridge* bridge = UAvalonPythonBridge::Get();
 	bridge->RunInPython_Manage();
-}
-
-void FAvalonModule::MenuWorkfiles() {
-	UAvalonPythonBridge* bridge = UAvalonPythonBridge::Get();
-	bridge->RunInPython_Workfiles();
 }
 
 IMPLEMENT_MODULE(FAvalonModule, Avalon)

--- a/Source/Avalon/Private/Avalon.cpp
+++ b/Source/Avalon/Private/Avalon.cpp
@@ -10,7 +10,7 @@ static const FName AvalonTabName("Avalon");
 // This function is triggered when the plugin is staring up
 void FAvalonModule::StartupModule()
 {
-	
+
 	// Create the Extender that will add content to the menu
 	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
 	TSharedPtr<FExtender> MenuExtender = MakeShareable(new FExtender());
@@ -21,7 +21,7 @@ void FAvalonModule::StartupModule()
 		FMenuExtensionDelegate::CreateRaw(this, &FAvalonModule::AddMenuEntry)
 	);
 	LevelEditorModule.GetMenuExtensibilityManager()->AddExtender(MenuExtender);
-	
+
 }
 
 void FAvalonModule::ShutdownModule()
@@ -64,6 +64,13 @@ void FAvalonModule::AddMenuEntry(FMenuBuilder& MenuBuilder)
 			FUIAction(FExecuteAction::CreateRaw(this, &FAvalonModule::MenuManage))
 		);
 
+		MenuBuilder.AddMenuEntry(
+			FText::FromString("Experimental tools ..."),
+			FText::FromString("Experimental tools"),
+			FSlateIcon(),
+			FUIAction(FExecuteAction::CreateRaw(this, &FAvalonModule::MenuExperimentalTools))
+		);
+
 	}
 	MenuBuilder.EndSection();
 }
@@ -87,6 +94,11 @@ void FAvalonModule::MenuPublish() {
 void FAvalonModule::MenuManage() {
 	UAvalonPythonBridge* bridge = UAvalonPythonBridge::Get();
 	bridge->RunInPython_Manage();
+}
+
+void FAvalonModule::MenuExperimentalTools() {
+	UAvalonPythonBridge* bridge = UAvalonPythonBridge::Get();
+	bridge->RunInPython_ExperimentalTools();
 }
 
 IMPLEMENT_MODULE(FAvalonModule, Avalon)

--- a/Source/Avalon/Public/Avalon.h
+++ b/Source/Avalon/Public/Avalon.h
@@ -14,12 +14,10 @@ public:
 private:
 
 	void AddMenuEntry(FMenuBuilder& MenuBuilder);
-	void FillSystemSubmenu(FMenuBuilder& MenuBuilder);
 	void MenuCreate();
 	void MenuLoad();
 	void MenuPublish();
 	void MenuManage();
 	void MenuWorkfiles();
-	void MenuProjectManager();
 
 };

--- a/Source/Avalon/Public/Avalon.h
+++ b/Source/Avalon/Public/Avalon.h
@@ -18,6 +18,5 @@ private:
 	void MenuLoad();
 	void MenuPublish();
 	void MenuManage();
-	void MenuWorkfiles();
 
 };

--- a/Source/Avalon/Public/Avalon.h
+++ b/Source/Avalon/Public/Avalon.h
@@ -18,5 +18,6 @@ private:
 	void MenuLoad();
 	void MenuPublish();
 	void MenuManage();
+	void MenuExperimentalTools();
 
 };

--- a/Source/Avalon/Public/AvalonPythonBridge.h
+++ b/Source/Avalon/Public/AvalonPythonBridge.h
@@ -25,7 +25,4 @@ public:
 
 	UFUNCTION(BlueprintImplementableEvent, Category = Python)
 		void RunInPython_Workfiles() const;
-
-	UFUNCTION(BlueprintImplementableEvent, Category = Python)
-		void RunInPython_ProjectManager() const;
 };

--- a/Source/Avalon/Public/AvalonPythonBridge.h
+++ b/Source/Avalon/Public/AvalonPythonBridge.h
@@ -22,4 +22,8 @@ public:
 
 	UFUNCTION(BlueprintImplementableEvent, Category = Python)
 		void RunInPython_Manage() const;
+
+	UFUNCTION(BlueprintImplementableEvent, Category = Python)
+		void RunInPython_ExperimentalTools() const;
+
 };

--- a/Source/Avalon/Public/AvalonPythonBridge.h
+++ b/Source/Avalon/Public/AvalonPythonBridge.h
@@ -22,7 +22,4 @@ public:
 
 	UFUNCTION(BlueprintImplementableEvent, Category = Python)
 		void RunInPython_Manage() const;
-
-	UFUNCTION(BlueprintImplementableEvent, Category = Python)
-		void RunInPython_Workfiles() const;
 };


### PR DESCRIPTION
## Changes
- removed project manager action (with System menu)
- removed unused workfiles tool action
- added new experimental dialog action

## Note
We should maybe think about adding only single action which would show Qt menu so we can dynamically change the content without recreating unreal project...

Depends on https://github.com/pypeclub/avalon-core/pull/395